### PR TITLE
Add custom button/link interchangeable component

### DIFF
--- a/components/common/fbButton.js
+++ b/components/common/fbButton.js
@@ -1,0 +1,59 @@
+import { PseudoBox } from '@chakra-ui/core'
+import PropTypes from 'prop-types'
+
+/*
+EXAMPLE USE CASES
+==================
+
+As an HTML button element (use for actions like submitting forms or events)
+<FBButton
+  as="button"
+  backgroundColor="puddle"
+  color="ocean"
+  padding="1.5em"
+  onClick={clickHandler}
+>
+  Click here
+ </FBButton>
+
+As a link (use where you would use a Link/HTML a element, to link to another page, fragment on the page (#someId), or external link)
+<FBButton
+  as="a"
+  href="/signup"
+>
+  Sign Up
+ </FBButton>
+*/
+
+const FBButton = ({ as, children, ...props }) => (
+  <PseudoBox as={as} {...props}>
+    {children}
+  </PseudoBox>
+)
+
+FBButton.defaultProps = {
+  display: 'inline-block',
+  margin: 0,
+  width: 'auto',
+  height: 'auto',
+  // most of the buttons and link "buttons" in the design file are this width, so it's a sensible default; set to 'none' on the instances that don't need it, like the Sign Up link in the nav
+  minW: '8.5rem',
+  padding: '.75rem 1rem',
+  backgroundColor: 'ocean',
+  color: 'white',
+  textAlign: 'center',
+  fontWeight: 600,
+  lineHeight: 'inherit',
+  borderRadius: '11px',
+  borderWidth: '0px',
+  borderColor: 'currentColor',
+  transition: 'all 250ms ease-in-out',
+  _hover: { transform: 'translateY(3px)' },
+  _active: { transform: 'translateY(6px)' }
+}
+
+FBButton.PropTypes = {
+  as: PropTypes.string.isRequired
+}
+
+export default FBButton

--- a/components/common/header.js
+++ b/components/common/header.js
@@ -1,6 +1,6 @@
 import { Box, Flex } from '@chakra-ui/core'
 
-import FBButton from '../common/button'
+import FBButton from '../common/fbButton'
 import FBLogo from '../common/logo'
 import TextLink from './textLink'
 
@@ -22,16 +22,18 @@ const Header = () => {
           >
             <TextLink url='/about' text='About Us' color='boulder' />
             <TextLink url='/login' text='Log In' color='boulder' />
-            {/* TODO: create LinkBtn component and replace */}
             <FBButton
-              borderColor='ocean'
-              width='auto'
-              margin='10px'
+              as='a'
+              href='/signup'
+              backgroundColor='transparent'
+              minW='unset'
               color='ocean'
-              variant='outline'
+              borderWidth='1px'
+              padding={['.5rem 1rem', '.75rem 2rem']}
+              margin='10px'
               _hover={{ backgroundColor: 'ocean', color: 'white' }}
             >
-              Sign up
+              Sign Up
             </FBButton>
           </Box>
         </Flex>

--- a/components/common/subheading.js
+++ b/components/common/subheading.js
@@ -6,7 +6,7 @@ const Subheading = ({ align, children, ...props }) => (
     textAlign={align}
     marginBottom='2rem'
     fontSize='1.5rem'
-    fontWeight='300'
+    fontWeight='400'
     {...props}
   >
     {children}

--- a/components/splash/splash_for_businesses.js
+++ b/components/splash/splash_for_businesses.js
@@ -1,7 +1,7 @@
 import { Flex, Text } from '@chakra-ui/core'
 import PropTypes from 'prop-types'
 
-import FBButton from '../common/button'
+import FBButton from '../common/fbButton'
 import BusinessCards from './cards/businessCards'
 import Section from './section'
 import Subheading from '../common/subheading'
@@ -25,13 +25,13 @@ const SplashForBusinesses = ({ id }) => {
 
         <BusinessCards />
 
-        {/* TODO: replace with a future LinkBtn component */}
         <Flex flexDirection='row' justify='space-around' marginBottom='20px'>
           <FBButton
-            backgroundColor='ocean'
-            width='auto'
-            color='white'
-            _hover={{ marginTop: '3px' }}
+            as='a'
+            href='/signup'
+            className='u-box-shadow'
+            minW='10rem'
+            padding='1rem'
           >
             Register
           </FBButton>

--- a/components/splash/splash_for_developers.js
+++ b/components/splash/splash_for_developers.js
@@ -1,18 +1,12 @@
 import { Flex, Box, Text, Heading, Icon } from '@chakra-ui/core'
-import { useRouter } from 'next/router'
 import PropTypes from 'prop-types'
 
 import FBDivider from '../common/divider'
 import useMedia from '../common/useMedia'
-import FBButton from '../common/button'
+import FBButton from '../common/fbButton'
 
 const SplashForDevelopers = (props) => {
   const isWide = useMedia('(min-width: 768px')
-  const router = useRouter()
-
-  const login = () => {
-    router.push('/login')
-  }
 
   return (
     <Box id={props.id}>
@@ -53,12 +47,13 @@ const SplashForDevelopers = (props) => {
             <>
               <Box height='40px'>
                 <FBButton
-                  backgroundColor='ocean'
-                  color='white'
-                  _hover={{ marginTop: '3px' }}
-                  onClick={login}
+                  as='a'
+                  href='/signup'
+                  className='u-box-shadow'
+                  padding='1rem'
+                  minW='10rem'
                 >
-                  Sign up
+                  Sign Up
                 </FBButton>
               </Box>
               <Text marginTop='30px'>Are you an author or maintainer?</Text>
@@ -146,12 +141,13 @@ const SplashForDevelopers = (props) => {
           <>
             <Box height='40px' marginTop='30px'>
               <FBButton
-                backgroundColor='ocean'
-                color='white'
-                _hover={{ marginTop: '3px' }}
-                onClick={login}
+                as='a'
+                href='/signup'
+                className='u-box-shadow'
+                padding='1rem'
+                minW='10rem'
               >
-                Sign up
+                Sign Up
               </FBButton>
             </Box>
             <Text marginTop='30px'>Are you an author or maintainer?</Text>

--- a/components/splash/splash_hero.js
+++ b/components/splash/splash_hero.js
@@ -6,7 +6,7 @@ import SplashRocket from '../../public/images/splash/splash_rocket_clouds.svg'
 import SplashComputer from '../../public/images/splash/splash_computer.svg'
 import SplashForegroundClouds from '../../public/images/splash/splash_foreground_clouds.svg'
 import SplashBackgroundClouds from '../../public/images/splash/splash_background_clouds.svg'
-import FBButton from '../common/button'
+import FBButton from '../common/fbButton'
 import useMedia from '../common/useMedia'
 import styles from './splash_hero.module.scss'
 
@@ -46,27 +46,28 @@ const SplashHero = (props) => {
         justify='center'
         margin='auto'
         padding={['20px', '0px']}
-        width={['auto', '50%']}
         flexDirection={['column', 'row']}
         marginTop='30px'
         marginBottom='10px'
       >
         <FBButton
+          as='a'
+          href='#forDevelopers'
+          className='u-box-shadow'
           backgroundColor='white'
           color='ocean'
-          variant='solid'
-          marginBottom={['20px', '0']}
-          _hover={{ marginTop: '3px' }}
-          onClick={props.handleScrollToDeveloperSection}
+          minW={['none', '10rem']}
+          margin={['0 0 1.5rem 0', '0 1.5rem 0 0 ']}
         >
           For Developers
         </FBButton>
         <FBButton
+          as='a'
+          href='#forBusinesses'
+          className='u-box-shadow'
           backgroundColor='puddle'
-          marginLeft={['0px', '20px']}
           color='ocean'
-          _hover={{ marginTop: '3px' }}
-          onClick={props.handleScrollToBusinessSection}
+          minW={['none', '10rem']}
         >
           For Businesses
         </FBButton>

--- a/components/splash/splash_what_is_flossbank.js
+++ b/components/splash/splash_what_is_flossbank.js
@@ -1,10 +1,9 @@
 import { Box, Flex, Text, Icon, Heading } from '@chakra-ui/core'
-import { useRouter } from 'next/router'
 
 import PeopleCollabing from '../../public/images/splash/splash_people_collabing.svg'
 import FBDivider from '../common/divider'
 import useMedia from '../common/useMedia'
-import FBButton from '../common/button'
+import FBButton from '../common/fbButton'
 
 const WhatIsFlossbankCard = (props) => {
   return (
@@ -29,15 +28,6 @@ const WhatIsFlossbankCard = (props) => {
 
 const SplashWhatIsFlossbank = () => {
   const isWide = useMedia('(min-width: 768px')
-  const router = useRouter()
-
-  const login = () => {
-    router.push('/login')
-  }
-
-  const goToAboutUs = () => {
-    router.push('/aboutUs')
-  }
 
   return (
     <Flex
@@ -91,19 +81,23 @@ const SplashWhatIsFlossbank = () => {
         </Flex>
         <Flex flexDirection='row' marginTop='20px'>
           <FBButton
-            backgroundColor='ocean'
-            color='white'
-            _hover={{ marginTop: '3px' }}
-            onClick={login}
+            as='a'
+            href='/signup'
+            className='u-box-shadow'
+            padding='.75rem'
+            minW='10rem'
           >
             Sign Up
           </FBButton>
           <FBButton
+            as='a'
+            href='/aboutus'
+            className='u-box-shadow'
+            padding='.75rem'
+            minW='10rem'
             backgroundColor='puddle'
             color='ocean'
-            marginLeft='20px'
-            _hover={{ marginTop: '3px' }}
-            onClick={goToAboutUs}
+            margin='0 0 0 1.5rem'
           >
             About Us
           </FBButton>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,40 +1,15 @@
+import Header from '../components/common/header'
 import SplashHero from '../components/splash/splash_hero'
 import SplashWhatIsFlossbank from '../components/splash/splash_what_is_flossbank'
+import SplashForDevelopers from '../components/splash/splash_for_developers'
 import SplashForBussinesses from '../components/splash/splash_for_businesses'
 import Footer from '../components/common/footer'
-import Header from '../components/common/header'
-import SplashForDevelopers from '../components/splash/splash_for_developers'
 
 function Splash () {
-  const scrollWindow = (offset) => {
-    window.scroll({
-      top: offset,
-      behavior: 'smooth'
-    })
-  }
-
-  const scrollToId = (id) => {
-    const $anchor = document.getElementById(id)
-    if (!$anchor) return
-    const offset = $anchor.getBoundingClientRect().top + window.pageYOffset
-    scrollWindow(offset)
-  }
-
-  const scrollToDeveloperSection = () => {
-    scrollToId('forDevelopers')
-  }
-
-  const scrollToBusinessSection = () => {
-    scrollToId('forBusinesses')
-  }
-
   return (
     <>
       <Header />
-      <SplashHero
-        handleScrollToDeveloperSection={scrollToDeveloperSection}
-        handleScrollToBusinessSection={scrollToBusinessSection}
-      />
+      <SplashHero />
       <SplashWhatIsFlossbank />
       <SplashForDevelopers id='forDevelopers' />
       <SplashForBussinesses id='forBusinesses' />

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -4,3 +4,7 @@
 
 @import "./_variables";
 @import "./_utilities";
+
+html {
+  scroll-behavior: smooth;
+}


### PR DESCRIPTION
- The default styles reflect these from the design since they are used the most, but can easily be overridden on an as-needed basis by passing whatever style props you to change.
![image](https://user-images.githubusercontent.com/16426195/83567745-ae7c3e00-a4e7-11ea-9010-0940e2bb0362.png)

- Right now, I'm using the `u-box-shadow` class to add box shadows to the buttons, but I might put a box shadow in the default props since it us used on most buttons and can be overridden with `boxShadow="none"` where it's not needed.

- I've gone through and replaced all of the buttons on the splash page use this component as a link, as they should be, and remove the click handlers/routing since it was not needed.

- Once I work my way through the other pages to replace everything, then the `button.js` component can be removed since we won't need it, but I left it for now to avoid any conflicts on things @joelwass may be working on at the moment.

To use it as a link that should look like a button, use the `as="a"` prop and provide an href to link or route:

```javascript
  <FBButton  as='a' href='/signup'>
      Register
   </FBButton>
```

To use it as a button for click events  or to submit forms, use the `as="button"` prop and `onClick`, or in a form, leave off `onClick` since the form should handle the submit.:

```javascript
  <FBButton as='button' onClick={doSomething}>
      Some text
  </FBButton>

```

The base component is a Chakra `PseudoBox` so `FBButton` can accept any of the usual style props as well as regular props like `id` or `aria` attributes, etc..

 