### PR TITLE
Spruce up

### DIFF
--- a/components/common/header/authNav.js
+++ b/components/common/header/authNav.js
@@ -1,8 +1,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
-
-import { useAuth } from '../../../utils/useAuth'
+import PropTypes from 'prop-types'
 
 import {
   useTheme,
@@ -15,9 +14,8 @@ import {
   MenuItem
 } from '@chakra-ui/core'
 
-const AuthNav = ({ user }) => {
+const AuthNav = ({ user, onLogout }) => {
   const router = useRouter()
-  const auth = useAuth()
 
   const [isExpanded, setIsExpanded] = useState(false)
   const { colors } = useTheme()
@@ -31,11 +29,6 @@ const AuthNav = ({ user }) => {
     color: 'lightPuddle',
     backgroundColor: 'ocean',
     outline: 'none !important'
-  }
-
-  const handleLogout = () => {
-    router.push('/')
-    auth.logout()
   }
 
   const handleNav = (dest) => router.push(dest)
@@ -116,7 +109,7 @@ const AuthNav = ({ user }) => {
                 </a>
               </Link>
             </MenuItem>
-            <MenuItem _focus={itemFocusStyles} onClick={handleLogout}>
+            <MenuItem _focus={itemFocusStyles} onClick={onLogout}>
               <Link href='/'>
                 <a>
                   <Icon name='unlock' marginRight='.5rem' />
@@ -129,6 +122,11 @@ const AuthNav = ({ user }) => {
       )}
     </Menu>
   )
+}
+
+AuthNav.propTypes = {
+  user: PropTypes.object.isRequired,
+  onLogout: PropTypes.func.isRequired
 }
 
 export default AuthNav

--- a/components/common/header/header.js
+++ b/components/common/header/header.js
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { useAuth } from '../../../utils/useAuth'
 
 import { Box, Flex } from '@chakra-ui/core'
@@ -8,7 +9,14 @@ import FBLogo from './logo'
 import AuthNav from './authNav'
 
 const Header = () => {
-  const user = useAuth().user
+  const router = useRouter()
+  const auth = useAuth()
+  const { user } = auth
+
+  const handleLogout = () => {
+    router.push('/')
+    auth.logout()
+  }
 
   return (
     <>
@@ -25,7 +33,7 @@ const Header = () => {
             maxW={['22.5rem', '22.5rem', '22.5rem', '34.5rem']}
             aria-label='Primary navigation'
           >
-            {user && <AuthNav user={user} />}
+            {user && <AuthNav user={user} onLogout={handleLogout} />}
             {!user && (
               <>
                 <TextLink

--- a/components/install/installSection.js
+++ b/components/install/installSection.js
@@ -51,7 +51,7 @@ InstallInstructions.propTypes = {
 }
 
 const PostInstallInstructions = ({ noAds }) => {
-  const topText = noAds ? "There's nothing else you need to do." : "Let's try it out!"
+  const topText = noAds ? "Thanks for choosing to support the Open Source community!" : "Let's try it out!"
   return (
     <Card
       id='post-install'

--- a/components/install/installSection.js
+++ b/components/install/installSection.js
@@ -1,6 +1,7 @@
 import {
   Box,
-  Text
+  Text,
+  Code
 } from '@chakra-ui/core'
 import { useEffect, useState } from 'react'
 
@@ -13,6 +14,8 @@ import Section from '../common/section'
 import UnderlinedHeading from '../common/underlinedHeading'
 import Subheading from '../common/subheading'
 import LinkBtn from '../common/linkBtn'
+import PropTypes from 'prop-types'
+import { useAuth } from '../../utils/useAuth'
 
 const steps = [
   {
@@ -29,8 +32,81 @@ const steps = [
   }
 ]
 
+const InstallInstructions = ({ token }) => (
+  <Card
+    shadowSz='lg'
+    maxW='55rem'
+    margin='0 auto 3rem'
+    textAlign='left'
+  >
+    <Text marginBottom='3rem'>
+        Copy and paste the applicable command in your shell to continue:
+    </Text>
+    <InstallCommands token={token} />
+  </Card>
+)
+
+InstallInstructions.propTypes = {
+  token: PropTypes.string.isRequired
+}
+
+const PostInstallInstructions = ({ noAds }) => {
+  const topText = noAds ? "There's nothing else you need to do." : "Let's try it out!"
+  return (
+    <Card
+      id='post-install'
+      shadowSz='lg'
+      maxW='55rem'
+      margin='0 auto 3rem'
+      textAlign='left'
+    >
+      <Text marginBottom='1rem'>
+        Great! {topText}
+      </Text>
+      <Text marginBottom='1rem'>
+        Flossbank wraps package managers (currently only <code>npm</code> and <code>yarn</code>).
+        This means that when you run your package manager to install a package, Flossbank will automatically be invoked.
+      </Text>
+      {noAds ? (
+        <Text marginBottom='1rem'>
+          Next time you run <code>npm</code> or <code>yarn</code>, Flossbank will silently determine the dependency tree of the packages installed and allocate your donation accordingly.
+        </Text>
+      ) : (
+        <>
+          <Text marginBottom='1rem'>
+            Try opening a new terminal window/tab and installing a package with <code>npm</code>:
+          </Text>
+          <Code
+            padding='1rem'
+            marginBottom='1rem'
+            backgroundColor='lightRock'
+            color='boulder'
+            width='100%'
+          >
+            npm install standard
+          </Code>
+          <Text marginBottom='2rem'>
+            You should see an ad or two during installation! If you don't, it's not your fault. <TextLink text="Let us know and we'll see what wrong." href='/contact' />
+          </Text>
+          <Text>
+            If you saw an ad, you're all set! Head to the Dashboard for a birds-eye view of your impact.
+          </Text>
+        </>
+      )}
+    </Card>
+  )
+}
+
+PostInstallInstructions.propTypes = {
+  noAds: PropTypes.bool.isRequired
+}
+
 const InstallSection = () => {
   const [token, setToken] = useState('')
+  const [finishedInstalling, setFinishedInstalling] = useState(false)
+  const auth = useAuth()
+
+  const noAds = auth.user && !!auth.user.optOutOfAds
 
   async function fetchInstallToken () {
     try {
@@ -78,35 +154,43 @@ const InstallSection = () => {
             determine where to distribute the funds you generate for Open Source. See {' '}
             <TextLink href='/how-it-works' external text='how it works' /> to learn more.
           </Text>
-          <Card
-            shadowSz='lg'
-            maxW='55rem'
-            margin='0 auto 3rem'
-            textAlign='left'
-          >
-            <Text marginBottom='3rem'>
-              Copy and paste the applicable command in your shell to continue:
-            </Text>
-            <InstallCommands token={token} />
-          </Card>
-
-          <Box>
-            <LinkBtn
-              href='/dashboard'
-              className='u-box-shadow'
-              display='block'
-              margin='0 0 1.5rem'
-              padding='1rem 1.75rem'
-              fontWeight='bold'
-            >
-              I've Finished Installing
-            </LinkBtn>
-            <TextLink
-              text="I'll finish installing later"
-              href='/dashboard'
-              fontWeight='400'
-            />
-          </Box>
+          <InstallInstructions token={token} />
+          {!finishedInstalling ? (
+            <Box>
+              <LinkBtn
+                onClick={() => setFinishedInstalling(true)}
+                href='#post-install'
+                className='u-box-shadow'
+                display='block'
+                margin='0 0 1.5rem'
+                padding='1rem 1.75rem'
+                fontWeight='bold'
+              >
+                I've Finished Installing
+              </LinkBtn>
+              <TextLink
+                text="I'll finish installing later"
+                href='/dashboard'
+                fontWeight='400'
+              />
+            </Box>
+          ) : (
+            <>
+              <PostInstallInstructions noAds={noAds} />
+              <Box>
+                <LinkBtn
+                  href='/dashboard'
+                  className='u-box-shadow'
+                  display='block'
+                  margin='0 0 1.5rem'
+                  padding='1rem 1.75rem'
+                  fontWeight='bold'
+                >
+                  Go to Dashboard
+                </LinkBtn>
+              </Box>
+            </>
+          )}
         </Box>
       </Box>
     </Section>

--- a/components/install/installSection.js
+++ b/components/install/installSection.js
@@ -51,7 +51,7 @@ InstallInstructions.propTypes = {
 }
 
 const PostInstallInstructions = ({ noAds }) => {
-  const topText = noAds ? "Thanks for choosing to support the Open Source community!" : "Let's try it out!"
+  const topText = noAds ? 'Thanks for choosing to support the Open Source community!' : "Let's try it out!"
   return (
     <Card
       id='post-install'
@@ -86,7 +86,7 @@ const PostInstallInstructions = ({ noAds }) => {
             npm install standard
           </Code>
           <Text marginBottom='2rem'>
-            You should see an ad or two during installation! If you don't, it's not your fault. <TextLink text="Let us know and we'll see what wrong." href='/contact' />
+            You should see an ad or two during installation! If you don't, it's not your fault. <TextLink text="Let us know and we'll see what went wrong." href='/contact' />
           </Text>
           <Text>
             If you saw an ad, you're all set! Head to the Dashboard for a birds-eye view of your impact.

--- a/components/select/donateForm.js
+++ b/components/select/donateForm.js
@@ -2,6 +2,7 @@ import { CardElement, useElements, useStripe } from '@stripe/react-stripe-js'
 import { Box, NumberInput, NumberInputField } from '@chakra-ui/core'
 import { useState } from 'react'
 
+import { useAuth } from '../../utils/useAuth'
 import { donate } from '../../client'
 import ErrorMessage from '../common/errorMessage'
 import FBButton from '../common/fbButton'
@@ -16,6 +17,7 @@ const DonateForm = (props) => {
   const [amount, setAmount] = useState(5)
   const [cardError, setCardError] = useState('')
   const [amountError, setAmountError] = useState('')
+  const { setOptOutOfAds } = useAuth()
 
   const handleAmount = (e) => {
     const amount = Number(e.target.value)
@@ -81,8 +83,10 @@ const DonateForm = (props) => {
         setError('Donation failed')
         return
       }
+      setOptOutOfAds(response.optOutOfAds)
       props.handleSuccess()
     } catch (e) {
+      setOptOutOfAds(false) // can't opt out if your donation failed
       switch (e.status) {
         case 409:
           setError('Donation already exists')

--- a/utils/useAuth.js
+++ b/utils/useAuth.js
@@ -67,9 +67,9 @@ function useProvideAuth () {
   const [user, setUser] = useState(null)
   const [_, setAuthedFlag] = useLocalStorage('flossbank_auth', false) // eslint-disable-line
 
-  const setSessionUser = (user) => {
-    setUser(user || null)
-    setAuthedFlag(!!user)
+  const setSessionUser = (u) => {
+    setUser(u || null)
+    setAuthedFlag(!!u)
   }
 
   const login = async (body) => {
@@ -98,12 +98,21 @@ function useProvideAuth () {
     setSessionUser(res.success && res.user)
   }
 
+  // allow donation changes to update user state;
+  // this way we don't need to ask API for user obj again to know if they won't be seeing ads.
+  // use case is install page, where it's helpful to know whether the user should expect
+  // to see ads after they install.
+  const setOptOutOfAds = (optOutOfAds) => {
+    setUser(Object.assign({}, user, { optOutOfAds }))
+  }
+
   return {
     resume,
     completeLogin,
     user,
     login,
     signup,
-    logout
+    logout,
+    setOptOutOfAds
   }
 }


### PR DESCRIPTION
1. Moved auth logic out of AuthNav; it was being passed a `user` prop, but also using the `useAuth` hook (which has the user object on it); the only reason it needed `auth` was for `auth.logout` so I passed in the logout function and the user object from its parent.
1. At time of donation, API will return whether or not the user's donation + seeAds setting resulted in them opting out of ads (https://github.com/flossbank/fastify-api/pull/119). Added persisting that to the user's session object in state.
1. Added post-install text on the /install page. If the user has opted out of ads, it explains that they won't see anything. If the user is expected to see ads, it walks them through (hopefully) seeing one.

design/copy/functionality of post-install copy is up for discussion since we don't have designs.