### PR TITLE
install reminder banner

### DIFF
--- a/components/common/banner.js
+++ b/components/common/banner.js
@@ -1,0 +1,49 @@
+import {
+  Flex,
+  Icon,
+  CloseButton
+} from '@chakra-ui/core'
+
+const Banner = ({ icon, children, onCloseClick }) => {
+  return (
+    <Flex
+      position='relative'
+      color='ocean'
+      width='100%'
+      backgroundColor='lightPuddle'
+      direction={{ base: 'column', md: 'row' }}
+      align='center'
+      justify='center'
+      padding={{ base: '1rem 1.5rem', md: '1.5rem 3rem' }}
+      margin='0 auto'
+      fontWeight='500'
+      borderColor='ocean'
+      borderBottom='1px'
+    >
+      <Icon
+        name={icon}
+        size={{ base: '2rem', md: '3rem' }}
+        marginRight={{ base: 0, md: '1.5rem' }}
+        marginBottom={{ base: '1.5rem', md: 0 }}
+      />
+      {children}
+      <CloseButton
+        onClick={onCloseClick}
+        border='2px solid'
+        color='currentColor'
+        borderRadius='50%'
+        aria-label='Dismiss message'
+        position='absolute'
+        top='.5rem'
+        right='1rem'
+        transition='all 200ms ease-in-out'
+        _hover={{
+          backgroundColor: 'ocean',
+          color: '#fff'
+        }}
+      />
+    </Flex>
+  )
+}
+
+export default Banner

--- a/components/install/installSection.js
+++ b/components/install/installSection.js
@@ -15,7 +15,9 @@ import UnderlinedHeading from '../common/underlinedHeading'
 import Subheading from '../common/subheading'
 import LinkBtn from '../common/linkBtn'
 import PropTypes from 'prop-types'
+import { useLocalStorage } from '../../utils/useLocalStorage'
 import { useAuth } from '../../utils/useAuth'
+import { localStorageDashboardInstallReminderKey } from '../../utils/constants'
 
 const steps = [
   {
@@ -104,9 +106,17 @@ PostInstallInstructions.propTypes = {
 const InstallSection = () => {
   const [token, setToken] = useState('')
   const [finishedInstalling, setFinishedInstalling] = useState(false)
+  const [_, setShowInstallReminder] = useLocalStorage( //eslint-disable-line
+    localStorageDashboardInstallReminderKey,
+    true
+  )
   const auth = useAuth()
-
   const noAds = auth.user && !!auth.user.optOutOfAds
+
+  function finishInstalling () {
+    setFinishedInstalling(true)
+    setShowInstallReminder(false)
+  }
 
   async function fetchInstallToken () {
     try {
@@ -158,7 +168,7 @@ const InstallSection = () => {
           {!finishedInstalling ? (
             <Box>
               <LinkBtn
-                onClick={() => setFinishedInstalling(true)}
+                onClick={finishInstalling}
                 href='#post-install'
                 className='u-box-shadow'
                 display='block'

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -8,7 +8,6 @@ import {
   ListItem,
   CircularProgress,
   Icon,
-  CloseButton,
   Button
 } from '@chakra-ui/core'
 
@@ -25,8 +24,12 @@ import {
 
 import { downloadData } from '../utils/downloader'
 import { useLocalStorage } from '../utils/useLocalStorage'
-import { localStorageDashboardWelcomeBannerKey } from '../utils/constants'
+import {
+  localStorageDashboardWelcomeBannerKey,
+  localStorageDashboardInstallReminderKey
+} from '../utils/constants'
 
+import Banner from '../components/common/banner'
 import PageWrapper from '../components/common/pageWrapper'
 import Section from '../components/common/section'
 import DashboardDataCard from '../components/dashboard/dashboardDataCard'
@@ -37,12 +40,18 @@ import {
   fetchDonationInfo,
   fetchUserSessionsInfo
 } from '../client'
+import TextLink from '../components/common/textLink'
 
 const Dashboard = () => {
   const [showWelcomeMessage, setShowWelcomeMessage] = useLocalStorage(
     localStorageDashboardWelcomeBannerKey,
     true
   )
+  const [showInstallReminder, setShowInstallReminder] = useLocalStorage(
+    localStorageDashboardInstallReminderKey,
+    true
+  )
+  const [showInstallReminderLocal, setShowInstallReminderLocal] = useState(true)
   const [packagesTouchedLoading, setPackagesTouchedLoading] = useState(true)
   const [donationLoading, setDonationLoading] = useState(true)
   const [userSessionCountLoading, setUserSessionCountLoading] = useState(true)
@@ -114,50 +123,31 @@ const Dashboard = () => {
 
   return (
     <PageWrapper title='Dashboard'>
-      <Section backgroundColor='lightRock'>
-        {showWelcomeMessage && (
-          <Flex
-            position='relative'
-            maxW={{ md: '60rem' }}
-            color='ocean'
-            backgroundColor='lightPuddle'
-            direction={{ base: 'column', md: 'row' }}
-            align='center'
-            justify='center'
-            padding={{ base: '1rem 1.5rem', md: '1.5rem 3rem' }}
-            margin='0 auto 3rem'
-            fontWeight='500'
-          >
-            <Icon
-              name='hooray'
-              size={{ base: '2rem', md: '3rem' }}
-              marginRight={{ base: 0, md: '1.5rem' }}
-              marginBottom={{ base: '1.5rem', md: 0 }}
-            />
+      {showWelcomeMessage && (
+        <Banner icon='hooray' onCloseClick={() => setShowWelcomeMessage(false)}>
+          <Text>
             Thanks for installing Flossbank! You can log in at any time to see
             the impact you have on the Open Source community. We're always
             working on more features, hoping to create a vibrant Open Source
             support ecosystem. Happy coding!
-            <CloseButton
-              onClick={() => setShowWelcomeMessage(false)}
-              border='2px solid'
-              color='currentColor'
-              borderRadius='50%'
-              aria-label='Dismiss message'
-              position='absolute'
-              top='.5rem'
-              right='1rem'
-              transition='all 200ms ease-in-out'
-              _hover={{
-                backgroundColor: 'ocean',
-                color: '#fff'
-              }}
-            />
-          </Flex>
-        )}
+          </Text>
+        </Banner>
+      )}
+      {(showInstallReminder && showInstallReminderLocal) && (
+        <Banner icon='info' onCloseClick={() => setShowInstallReminderLocal(false)}>
+          <Text>
+            Looks like you haven't installed the package manager wrapper yet.
+            Head over to <TextLink textDecoration='underline' fontWeight='bold' text='the install page' href='/install' /> to finish setting up and ensure
+            the packages you install are compensated. If you've already
+            installed, <TextLink textDecoration='underline' fontWeight='bold' href='#' onClick={() => setShowInstallReminder(false)} text='click here.' />
+          </Text>
+        </Banner>
+      )}
+      <Section backgroundColor='lightRock'>
         <Heading
           textTransform='uppercase'
           fontWeight='bold'
+          marginTop='0'
           fontSize='1rem'
           textAlign={{ base: 'center', sm: 'left' }}
           marginBottom='1.5rem'
@@ -269,7 +259,7 @@ const Dashboard = () => {
                   <Label angle={270} position='left' value='Count' />
                 </YAxis>
                 <Tooltip />
-                <Bar dataKey='count' fill='#8884d8' />
+                <Bar dataKey='count' fill='#2baf74' />
               </BarChart>
             </ResponsiveContainer>
           </Box>

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,4 +1,5 @@
 export const localStorageDashboardWelcomeBannerKey = 'flossbank_u_show_welcome_banner'
+export const localStorageDashboardInstallReminderKey = 'flossbank_u_show_install_reminder'
 export const localStorageLoggedIn = 'flossbank_u_logged_in'
 
 export const allowedEndpoints = [


### PR DESCRIPTION
* refactored "banner" into its own component
* made color of chart a compliment of our "ocean" color
* added a new "install reminder" banner to reminder users who clicked "install later" to go back and finish setup (see screenshot)
* also note that the banner can be dismissed in a local session, but until they _install_ on the install page or "click here" to say they've installed, the banner will show itself again on refresh

<img width="1377" alt="Screen Shot 2020-07-13 at 9 00 22 PM" src="https://user-images.githubusercontent.com/7344422/87382485-e8f7e280-c54b-11ea-8d9a-074819a42aa9.png">

