### PR TITLE
Add update billing info section to User Settings page

### DIFF
--- a/components/user/settings/settingsSection.js
+++ b/components/user/settings/settingsSection.js
@@ -1,14 +1,49 @@
-import { Text } from '@chakra-ui/core'
+import { useState, useRef } from 'react'
+
+import {
+  Text,
+  Button,
+  Heading,
+  Box,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  useDisclosure,
+  ModalBody,
+  ModalFooter
+} from '@chakra-ui/core'
 
 import Section from '../../common/section'
 import Card from '../../common/card'
 import UnderlinedHeading from '../../common/underlinedHeading'
+// import FBButton from '../../common/fbButton'
 
 import { useAuth } from '../../../utils/useAuth'
 
-const UserSettingsSection = ({ ...props }) => {
-  const { user } = useAuth()
+const BillingInfo = (user) => {
+  console.log(user.user.billingInfo)
+  return (
+    <Box as='dl' display='flex'>
+      <Box as='dt' fontWeight='500' marginRight='1rem'>
+        Credit Card Number:
+      </Box>
+      <Box as='dd'>
+        <span aria-hidden='true'>{'•••• '.repeat(3)} </span>
+        {user.user.billingInfo.last4}
+      </Box>
+    </Box>
+  )
+}
 
+const UserSettingsSection = () => {
+  const { user } = useAuth()
+  const [hasBillingInfo, setHasBillingInfo] = useState(user.billingInfo.last4)
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const finalRef = useRef()
+
+  console.log(user)
   return (
     <Section
       display='flex'
@@ -16,28 +51,80 @@ const UserSettingsSection = ({ ...props }) => {
       flexDirection='column'
       alignItems='center'
       padding={{ base: '3rem 1.5rem', lg: '4rem 7.5rem' }}
-      backgroundColor='white'
-      {...props}
+      backgroundColor='lightRock'
     >
-      <UnderlinedHeading text='User Settings' align='center' marginBottom='3rem' />
-      <Card shadowSz='lg' w='100%' maxW='80%'>
-        <Text
+      <UnderlinedHeading
+        as='h1'
+        text='User Settings'
+        align='center'
+        marginBottom='3rem'
+      />
+      <Card shadowSz='lg' w='100%' maxW='50rem'>
+        <Heading
           textTransform='uppercase'
-          textAlign={{ base: 'center', lg: 'left' }}
+          textAlign={{ base: 'center', md: 'left' }}
           color='ocean'
           fontWeight='bold'
-          fontSize='0.875rem'
+          fontSize='1rem'
           marginBottom='1.5rem'
         >
-          Billing info
-        </Text>
-        <Text>
-          Payment method
-        </Text>
-        <Text>
-          {user.billingInfo.last4 ? `****-****-****-${user.billingInfo.last4}` : 'N/a'}
-        </Text>
+          Billing Information
+        </Heading>
+        <Box marginBottom='1.5rem'>
+          {!hasBillingInfo && (
+            <>
+              <Text marginBottom='1.5rem'>
+                <strong>
+                  You currently have no billing information on file.
+                </strong>
+              </Text>
+              <Text>
+                Adding billing information will allow you to donate to the Open
+                Source packages you use most.
+              </Text>
+            </>
+          )}
+          {hasBillingInfo && <BillingInfo user={user} />}
+        </Box>
+        <Button
+          backgroundColor='puddle'
+          color='ocean'
+          className='u-box-shadow'
+          borderRadius='5px'
+          padding='1.5rem'
+          transition='all 300ms ease-in-out'
+          _hover={{
+            backgroundColor: 'ocean',
+            color: 'white',
+            transform: 'translateY(3px)'
+          }}
+          _active={{
+            backgroundColor: 'ocean',
+            color: 'white'
+          }}
+          ref={finalRef}
+          onClick={onOpen}
+        >
+          {hasBillingInfo
+            ? 'Update billing information'
+            : 'Add billing information'}
+        </Button>
       </Card>
+      <Modal isOpen={isOpen} size='xl' onClose={onClose}>
+        <ModalOverlay backgroundColor='rgba(0, 0, 0, .75)' />
+        <ModalContent backgroundColor='white' padding='2rem'>
+          <ModalHeader>
+            <UnderlinedHeading
+              text='Updating Billing Information'
+              align='left'
+              marginBottom='0'
+            />
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody />
+          <ModalFooter />
+        </ModalContent>
+      </Modal>
     </Section>
   )
 }

--- a/components/user/settings/settingsSection.js
+++ b/components/user/settings/settingsSection.js
@@ -10,40 +10,42 @@ import {
   ModalContent,
   ModalHeader,
   ModalCloseButton,
-  useDisclosure,
-  ModalBody,
-  ModalFooter
+  useDisclosure
 } from '@chakra-ui/core'
+
+import StripeWrapper from '../../common/stripe/stripeWrapper'
+import UpdateBilling from './updateBilling'
 
 import Section from '../../common/section'
 import Card from '../../common/card'
 import UnderlinedHeading from '../../common/underlinedHeading'
-// import FBButton from '../../common/fbButton'
 
 import { useAuth } from '../../../utils/useAuth'
 
-const BillingInfo = (user) => {
-  console.log(user.user.billingInfo)
-  return (
-    <Box as='dl' display='flex'>
-      <Box as='dt' fontWeight='500' marginRight='1rem'>
-        Credit Card Number:
-      </Box>
-      <Box as='dd'>
-        <span aria-hidden='true'>{'•••• '.repeat(3)} </span>
-        {user.user.billingInfo.last4}
-      </Box>
+const BillingInfo = ({ last4CardDigits }) => (
+  <Box as='dl' display='flex'>
+    <Box as='dt' fontWeight='500' marginRight='1rem'>
+      Credit Card Number:
     </Box>
-  )
-}
+    <Box as='dd'>
+      <span aria-hidden='true'>{'•••• '.repeat(3)} </span>
+      {last4CardDigits}
+    </Box>
+  </Box>
+)
 
 const UserSettingsSection = () => {
   const { user } = useAuth()
-  const [hasBillingInfo, setHasBillingInfo] = useState(user.billingInfo.last4)
+  const [last4CardDigits, setLast4CardDigits] = useState(
+    user.billingInfo.last4
+  )
   const { isOpen, onOpen, onClose } = useDisclosure()
   const finalRef = useRef()
 
-  console.log(user)
+  const handleUpdateBillingInfo = (billingInfo) => {
+    setLast4CardDigits(billingInfo.last4)
+  }
+
   return (
     <Section
       display='flex'
@@ -71,7 +73,7 @@ const UserSettingsSection = () => {
           Billing Information
         </Heading>
         <Box marginBottom='1.5rem'>
-          {!hasBillingInfo && (
+          {!last4CardDigits && (
             <>
               <Text marginBottom='1.5rem'>
                 <strong>
@@ -84,7 +86,7 @@ const UserSettingsSection = () => {
               </Text>
             </>
           )}
-          {hasBillingInfo && <BillingInfo user={user} />}
+          {last4CardDigits && <BillingInfo last4CardDigits={last4CardDigits} />}
         </Box>
         <Button
           backgroundColor='puddle'
@@ -105,12 +107,17 @@ const UserSettingsSection = () => {
           ref={finalRef}
           onClick={onOpen}
         >
-          {hasBillingInfo
+          {last4CardDigits
             ? 'Update billing information'
             : 'Add billing information'}
         </Button>
       </Card>
-      <Modal isOpen={isOpen} size='xl' onClose={onClose}>
+      <Modal
+        isOpen={isOpen}
+        size='xl'
+        closeOnOverlayClick={false}
+        onClose={onClose}
+      >
         <ModalOverlay backgroundColor='rgba(0, 0, 0, .75)' />
         <ModalContent backgroundColor='white' padding='2rem'>
           <ModalHeader>
@@ -121,8 +128,12 @@ const UserSettingsSection = () => {
             />
           </ModalHeader>
           <ModalCloseButton />
-          <ModalBody />
-          <ModalFooter />
+          <StripeWrapper>
+            <UpdateBilling
+              onClose={onClose}
+              UpdateBilling={handleUpdateBillingInfo}
+            />
+          </StripeWrapper>
         </ModalContent>
       </Modal>
     </Section>

--- a/components/user/settings/updateBilling.js
+++ b/components/user/settings/updateBilling.js
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { CardElement, useElements, useStripe } from '@stripe/react-stripe-js'
+
+import { Box, ModalBody, ModalFooter, Icon } from '@chakra-ui/core'
+
+import BillingForm from '../../dashboard/billingForm'
+import FBButton from '../../common/fbButton'
+import ErrorMessage from '../../common/errorMessage'
+
+const UpdateBilling = ({ updateBillingInfo, onClose }) => {
+  const [submitLoading, setSubmitLoading] = useState(false)
+  const stripe = useStripe()
+  const elements = useElements()
+  const [cardError, setCardError] = useState('')
+  const [submitError, setSubmitError] = useState(""); // eslint-disable-line
+
+  const handleSaveBilling = async () => {
+    setSubmitLoading(true)
+    // prevent quick button flash from isLoading event when there is a known error with the card
+    if (cardError) {
+      setSubmitLoading(false)
+      return
+    }
+
+    let token
+
+    try {
+      const cardElement = elements.getElement(CardElement)
+      const res = await stripe.createToken(cardElement)
+      token = res.token
+      updateBillingInfo(token.card.last4)
+    } catch (e) {
+      setSubmitError(e.message)
+      setSubmitLoading(false)
+      return
+    }
+
+    if (!token) {
+      setCardError('Invalid credit card information')
+      setSubmitLoading(false)
+    }
+
+    // TODO: handle updating billing info; call onClose at the end of success
+  }
+
+  return (
+    <>
+      <ModalBody>
+        <BillingForm />
+      </ModalBody>
+      {cardError && <ErrorMessage msg={cardError} marginTop='1rem' />}
+      <ModalFooter display='flex' justifyContent='space-evenly'>
+        <FBButton
+          onClick={onClose}
+          className='u-box-shadow'
+          backgroundColor='lightRock'
+          color='ocean'
+          fontWeight='600'
+        >
+          <Box as='span' display='flex' alignItems='center'>
+            <Icon name='close' fontSize='1rem' marginRight='1rem' />
+            Cancel
+          </Box>
+        </FBButton>
+        <FBButton
+          onClick={handleSaveBilling}
+          isLoading={submitLoading}
+          loadingText='Saving billing information…'
+          className='u-box-shadow'
+          fontWeight='600'
+        >
+          <Box as='span' display='flex' alignItems='center'>
+            <Icon name='check' fontSize='1rem' marginRight='1rem' />
+            Save billing information
+          </Box>
+        </FBButton>
+      </ModalFooter>
+    </>
+  )
+}
+
+export default UpdateBilling


### PR DESCRIPTION
(still needs the update logic which @joelwass is adding)

A user without billing info on file will see this:

<img width="862" alt="Screen Shot 2020-07-14 at 12 06 20 PM" src="https://user-images.githubusercontent.com/16426195/87455921-d02f1180-c5cb-11ea-96ad-299e55411c4b.png">
