### PR TITLE
slight tweaks to ui

### DIFF
--- a/components/dashboard/topTenPackagesView.js
+++ b/components/dashboard/topTenPackagesView.js
@@ -1,4 +1,4 @@
-import { Text, Heading, Icon } from '@chakra-ui/core'
+import { Text, Heading, Icon, Flex } from '@chakra-ui/core'
 
 import {
   BarChart,
@@ -25,7 +25,7 @@ const TopTenPlaceholder = () => (
 )
 
 const TopTenChart = ({ topTenPackages }) => (
-  <ResponsiveContainer width='100%' height={500}>
+  <ResponsiveContainer width='100%' height={490}>
     <BarChart
       data={topTenPackages}
       margin={{
@@ -48,19 +48,21 @@ const TopTenChart = ({ topTenPackages }) => (
 
 const TopTenPackagesView = ({ topTenPackages }) => (
   <>
-    <Heading
-      textTransform='uppercase'
-      fontWeight='bold'
-      marginTop='0'
-      fontSize='1rem'
-      textAlign={{ base: 'center', sm: 'left' }}
-      marginBottom='1.5rem'
-      display='flex'
-      alignItems='center'
-    >
-      <Icon name='duotoneStar' size='2em' marginRight='.5em' /> Top Ten Packages
-      Used
-    </Heading>
+    <Flex flexDirection='row'>
+      <Icon name='duotoneStar' size='2em' marginRight='.5em' marginTop='-0.5em' />
+      <Heading
+        textTransform='uppercase'
+        fontWeight='bold'
+        marginTop='0'
+        fontSize='1rem'
+        textAlign={{ base: 'center', sm: 'left' }}
+        marginBottom='1.5rem'
+        display='flex'
+        alignItems='center'
+      >
+        Top Ten Packages Used
+      </Heading>
+    </Flex>
     <DashboardDataCard
       display='flex'
       justifyContent='center'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "standard --fix",
+    "lint": "standard",
     "test": "API_HOST='https://api.flossbank.com' jest"
   },
   "husky": {

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -175,7 +175,7 @@ const Dashboard = () => {
         display={{ md: 'grid' }}
         gridTemplateColumns={{ lg: 'minmax(16rem, 20rem) 1fr' }}
         gridColumnGap={{ md: '3rem' }}
-        gridRowGap={{ base: '3rem', lg: '1.5rem' }}
+        gridRowGap={{ base: '3rem', lg: '3rem' }}
         gridTemplateRows={{ lg: 'auto 3rem 3rem' }}
       >
         <Box gridRow='1 / span 3' gridColumn='1'>
@@ -267,7 +267,7 @@ const Dashboard = () => {
         </Box>
         <Box
           marginTop={{ base: '3rem', lg: '0' }}
-          gridRow='2 / span 2'
+          gridRow='2 / span 1'
           gridColumn='2'
           justifySelf='end'
           alignSelf='end'
@@ -280,11 +280,10 @@ const Dashboard = () => {
             borderRadius='0'
             color='ocean'
             fontSize='1.5rem'
-            onClick={() =>
-              downloadData(
-                JSON.stringify(userInstallData),
-                'flossbank_user_data.json'
-              )}
+            onClick={() => downloadData(
+              JSON.stringify(userInstallData),
+              'flossbank_user_data.json'
+            )}
           >
             Download Data
             <Icon marginLeft='1rem' name='download' size='1.75rem' />


### PR DESCRIPTION
100% zoom on chrome:
* made the icon and title for top ten chart aligned with the impact overview header

<img width="1433" alt="Screen Shot 2020-07-15 at 3 20 58 PM" src="https://user-images.githubusercontent.com/7344422/87606009-d0540d80-c6ae-11ea-87b5-0a25d2a482d9.png">


change to where the download data is in the grid:

<img width="1412" alt="Screen Shot 2020-07-15 at 3 21 28 PM" src="https://user-images.githubusercontent.com/7344422/87606030-df3ac000-c6ae-11ea-8d02-c152420b5ce1.png">
