### PR TITLE
Revert "height of graph"

### DIFF
--- a/components/dashboard/topTenPackagesView.js
+++ b/components/dashboard/topTenPackagesView.js
@@ -25,7 +25,7 @@ const TopTenPlaceholder = () => (
 )
 
 const TopTenChart = ({ topTenPackages }) => (
-  <ResponsiveContainer width='100%' height='100%'>
+  <ResponsiveContainer width='100%' height={490}>
     <BarChart
       data={topTenPackages}
       margin={{

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -263,17 +263,12 @@ const Dashboard = () => {
             </List>
           </Box>
         </Box>
-        <Box
-          width='100%'
-          display={{ base: 'none', sm: 'initial' }}
-          gridRow='1 / span 2'
-          gridColumn='2'
-        >
+        <Box width='100%' display={{ base: 'none', sm: 'initial' }}>
           <TopTenPackagesView topTenPackages={topTenPackages} />
         </Box>
         <Box
           marginTop={{ base: '3rem', lg: '0' }}
-          gridRow='3 / span 1'
+          gridRow='2 / span 1'
           gridColumn='2'
           justifySelf='end'
           alignSelf='end'


### PR DESCRIPTION
Reverts flossbank/splash#89

The dashboard is broken with #89 merged, at least in FF. Graph grows infinitely downwards.