### PR TITLE
Fix amount error message on edit donation view

### DIFF
--- a/components/dashboard/donation/editDonationModalBody.js
+++ b/components/dashboard/donation/editDonationModalBody.js
@@ -99,7 +99,6 @@ const EditDonationModalBody = ({ donationAmount, isNewDonor, onClose }) => {
 
   const validateForm = () => {
     if (newAmount < 5) {
-      setSubmitError('Donation must be above ')
       return false
     }
     return true


### PR DESCRIPTION
Just a small tweak. Removed this line because when the amount is less than 5, we're already setting `amountError` to show the relevant message.
