### PR TITLE
Remove red asterisk from auth forms

### DIFF
--- a/components/common/authProcess.js
+++ b/components/common/authProcess.js
@@ -21,6 +21,8 @@ import FBButton from './fbButton'
 import TextLink from './textLink'
 import ErrorMessage from './errorMessage'
 
+import styles from './authProcess.module.scss'
+
 const AuthProcess = ({
   process,
   icon,
@@ -105,7 +107,7 @@ const AuthProcess = ({
             <Box as='form' onSubmit={handleSubmit(handleProcess)} noValidate>
               {formError && <ErrorMessage msg={formError} />}
               <FormControl marginBottom='2.25rem' isRequired>
-                <FormLabel htmlFor='email' marginBottom='.5rem'>
+                <FormLabel htmlFor='email' marginBottom='.5rem' className={styles.label}>
                   Email address
                 </FormLabel>
                 <Box aria-atomic='true' id='email-error'>
@@ -118,6 +120,7 @@ const AuthProcess = ({
                   id='email'
                   backgroundColor='lightRock'
                   name='email'
+                  autoComplete='email'
                   aria-describedby='email-error'
                   ref={register({
                     required: true,

--- a/components/common/authProcess.module.scss
+++ b/components/common/authProcess.module.scss
@@ -1,0 +1,4 @@
+// removes the red asterisk from the login/signup form (since it's just one input, it's of course required)
+.label > span {
+  display: none !important;
+}


### PR DESCRIPTION
Addresses Eryn's critique (which I agree with) that since there is just one input on the login and signup pages, we shouldn't use an asterisk or any sort of visual "required" indicator, since it is of course required. It's something added by Chakra by default for fields marked as required, so I needed to add a SCSS module to hide the span Chakra inserts.